### PR TITLE
Update configuration to include a default filesystem disk for media storage, ensuring compatibility with the Filament framework. Added a new line for clarity and improved documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # SabHero Portfolio Package
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/fuelviews/laravel-sabhero-portfolio.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-sabhero-portfolio)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/fuelviews/laravel-sabhero-portfolio/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/fuelviews/laravel-sabhero-portfolio/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/fuelviews/laravel-sabhero-portfolio/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/fuelviews/laravel-sabhero-portfolio/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/fuelviews/laravel-sabhero-portfolio.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-sabhero-portfolio)
 
 A Laravel package for managing and displaying before/after image portfolios with a dynamic slider component. Perfect for renovation projects, home improvements, design transformations, or any visual comparison showcase.

--- a/config/sabhero-portfolio.php
+++ b/config/sabhero-portfolio.php
@@ -15,6 +15,7 @@ return [
     | The 'all' type is required and will always be included.
     |
     */
+
     'portfolio_types' => [
         'all' => [
             'label' => 'all',
@@ -32,15 +33,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Media Storage Disk
+    | Default Filesystem Disk
     |--------------------------------------------------------------------------
     |
-    | You can specify which disk to use for storing media files.
-    | If not specified, it will use the default disk configured in the
-    | Spatie Media Library config ('media-library.disk').
-    |
-    | Example values: 'public', 's3', 'cloudinary', etc.
+    | This is the storage disk Filament will use to store files. You may use
+    | any of the disks defined in the `config/filesystems.php`.
     |
     */
-    'media_disk' => null,
+
+    'media_disk' => env('FILAMENT_FILESYSTEM_DISK', 'public'),
 ];


### PR DESCRIPTION
### Pull Request Description: Update configuration to include a default filesystem disk for media storage, ensuring compatibility with the Filament framework.

This pull request introduces a default filesystem disk configuration for media storage in the `sabhero-portfolio` project. The goal is to enhance compatibility with the Filament framework by explicitly defining the `media_disk` setting.

**Motivation:**
The Filament framework requires a designated filesystem disk for file storage to function correctly. By updating the configuration to set a default disk (using the `FILAMENT_FILESYSTEM_DISK` environment variable), we ensure that our application seamlessly integrates with Filament, reducing potential errors and improving user experience.

In addition to the primary change, a new line has been added for clarity and improved documentation. The comments now clearly explain the purpose of the `media_disk` setting and specify that it can utilize any disk defined in `config/filesystems.php`.

**Benefits:**
- Improved compatibility with the Filament framework, enabling efficient media handling.
- Clearer documentation for future developers, making it easier to understand the configuration's purpose.
- Flexibility to change the storage disk via environment variables without modifying the codebase.

This update is a crucial step towards enhancing our project's robustness and maintainability.