### PR TITLE
Refactor the description field in the portfolio form to use a TextArea component instead of a MarkdownEditor, enabling autosizing for better user experience.

### DIFF
--- a/src/Models/Portfolio.php
+++ b/src/Models/Portfolio.php
@@ -50,8 +50,9 @@ class Portfolio extends Model implements HasMedia
                                 ->required()
                                 ->maxLength(255),
 
-                            Forms\Components\MarkdownEditor::make('description')
+                            Forms\Components\TextArea::make('description')
                                 ->required()
+                                ->autosize()
                                 ->columnSpanFull(),
 
                             Forms\Components\Select::make('spacing')


### PR DESCRIPTION
### Pull Request Description

This pull request refactors the description field in the portfolio form by replacing the `MarkdownEditor` component with a `TextArea` component that supports autosizing. 

**Motivation:**
The primary motivation behind this change is to enhance the user experience when entering descriptions. The `MarkdownEditor` can be cumbersome for users who may not need markdown formatting, leading to potential confusion and a less intuitive interface. By switching to a `TextArea`, we provide a straightforward text input that automatically adjusts its size based on the content, making it easier for users to see what they are typing without needing to scroll.

**Improvements:**
- **User Experience**: The autosizing feature allows for a more fluid and responsive input experience, reducing frustration and improving usability.
- **Simplicity**: Removing the markdown formatting requirement simplifies the input process, making it more accessible to users unfamiliar with markdown syntax.
- **Consistency**: Aligning the description input method with standard text input practices enhances consistency across the form.

Overall, this change aims to create a more user-friendly portfolio form, ultimately leading to better user satisfaction and engagement.