### PR TITLE
Fix typo in the TextArea component name to ensure proper functionality in the form.

### DIFF
--- a/src/Models/Portfolio.php
+++ b/src/Models/Portfolio.php
@@ -50,7 +50,7 @@ class Portfolio extends Model implements HasMedia
                                 ->required()
                                 ->maxLength(255),
 
-                            Forms\Components\TextArea::make('description')
+                            Forms\Components\Textarea::make('description')
                                 ->required()
                                 ->autosize()
                                 ->columnSpanFull(),


### PR DESCRIPTION
Corrects a typo in the TextArea component name within the Portfolio model to ensure proper functionality in the form. The change updates the component name from `TextArea` to `Textarea`, aligning it with the correct casing used in the framework.

### Changes:
- Updated the component name from `TextArea` to `Textarea` in the `src/Models/Portfolio.php` file.