### PR TITLE
Update the README to remove the optional database seeding instructions and add integration steps for attaching the SabHero Portfolio plugin to the Filament panel. This enhances clarity on installation and integration processes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ php artisan vendor:publish --tag="sabhero-portfolio-migrations"
 php artisan migrate
 ```
 
-Optionally, you can seed the database with sample data:
-
-```bash
-php artisan db:seed --class="Fuelviews\\SabHeroPortfolio\\Database\\Seeders\\SabHeroPortfolioSeeder"
-```
-
 You can publish the config file with:
 
 ```bash
@@ -45,6 +39,24 @@ Optionally, you can publish the views using
 
 ```bash
 php artisan vendor:publish --tag="sabhero-portfolio-views"
+```
+
+## Integration
+
+### 1. Attach to Filament Panel
+
+Add the SabHero Portfolio plugin to your Filament panel provider:
+
+```php
+use Fuelviews\SabHeroArticle\Facades\SabHeroPortfolio;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            SabHeroPortfolio::make()
+        ]);
+}
 ```
 
 ## Usage


### PR DESCRIPTION
Updates the README file to enhance clarity regarding installation and integration processes. It removes the optional database seeding instructions and adds detailed steps for integrating the SabHero Portfolio plugin with the Filament panel.

### Changes:
1. Removed the optional database seeding instructions from the README.
2. Added a new section for integration steps, specifically for attaching the SabHero Portfolio plugin to the Filament panel.